### PR TITLE
[gitian] set correct PATH for wrappers

### DIFF
--- a/contrib/gitian-descriptors/gitian-linux.yml
+++ b/contrib/gitian-descriptors/gitian-linux.yml
@@ -68,11 +68,11 @@ script: |
   done
   }
 
-  export PATH=${WRAP_DIR}:${PATH}
-
   # Faketime for depends so intermediate results are comparable
+  export PATH_orig=${PATH}
   create_global_faketime_wrappers "2000-01-01 12:00:00"
   create_per-host_faketime_wrappers "2000-01-01 12:00:00"
+  export PATH=${WRAP_DIR}:${PATH}
 
   cd bitcoin
   BASEPREFIX=`pwd`/depends
@@ -82,8 +82,10 @@ script: |
   done
 
   # Faketime for binaries
+  export PATH=${PATH_orig}
   create_global_faketime_wrappers "${REFERENCE_DATETIME}"
   create_per-host_faketime_wrappers "${REFERENCE_DATETIME}"
+  export PATH=${WRAP_DIR}:${PATH}
 
   # Create the release tarball using (arbitrarily) the first host
   ./autogen.sh

--- a/contrib/gitian-descriptors/gitian-osx.yml
+++ b/contrib/gitian-descriptors/gitian-osx.yml
@@ -77,11 +77,11 @@ script: |
   done
   }
 
-  export PATH=${WRAP_DIR}:${PATH}
-
   # Faketime for depends so intermediate results are comparable
+  export PATH_orig=${PATH}
   create_global_faketime_wrappers "2000-01-01 12:00:00"
   create_per-host_faketime_wrappers "2000-01-01 12:00:00"
+  export PATH=${WRAP_DIR}:${PATH}
 
   cd bitcoin
   BASEPREFIX=`pwd`/depends
@@ -95,8 +95,10 @@ script: |
   done
 
   # Faketime for binaries
+  export PATH=${PATH_orig}
   create_global_faketime_wrappers "${REFERENCE_DATETIME}"
   create_per-host_faketime_wrappers "${REFERENCE_DATETIME}"
+  export PATH=${WRAP_DIR}:${PATH}
 
   # Create the release tarball using (arbitrarily) the first host
   ./autogen.sh

--- a/contrib/gitian-descriptors/gitian-win.yml
+++ b/contrib/gitian-descriptors/gitian-win.yml
@@ -94,12 +94,12 @@ script: |
   done
   }
 
-  export PATH=${WRAP_DIR}:${PATH}
-
   # Faketime for depends so intermediate results are comparable
+  export PATH_orig=${PATH}
   create_global_faketime_wrappers "2000-01-01 12:00:00"
   create_per-host_faketime_wrappers "2000-01-01 12:00:00"
   create_per-host_linker_wrapper "2000-01-01 12:00:00"
+  export PATH=${WRAP_DIR}:${PATH}
 
   cd bitcoin
   BASEPREFIX=`pwd`/depends
@@ -109,9 +109,11 @@ script: |
   done
 
   # Faketime for binaries
+  export PATH=${PATH_orig}
   create_global_faketime_wrappers "${REFERENCE_DATETIME}"
   create_per-host_faketime_wrappers "${REFERENCE_DATETIME}"
   create_per-host_linker_wrapper "${REFERENCE_DATETIME}"
+  export PATH=${WRAP_DIR}:${PATH}
 
   # Create the release tarball using (arbitrarily) the first host
   ./autogen.sh


### PR DESCRIPTION
I was setting the PATH incorrectly for the wrappers (#7283). This didn't matter for linux and osx builds but the windows ones were trying to wrap the linker twice.
