### PR TITLE
CNodeState encapsulation, lock reduction

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -106,6 +106,7 @@ BITCOIN_CORE_H = \
   net.h \
   netbase.h \
   noui.h \
+  peer.h \
   policy/fees.h \
   policy/policy.h \
   policy/rbf.h \
@@ -174,6 +175,7 @@ libbitcoin_server_a_SOURCES = \
   miner.cpp \
   net.cpp \
   noui.cpp \
+  peer.cpp \
   policy/fees.cpp \
   policy/policy.cpp \
   pow.cpp \

--- a/src/Makefile.test.include
+++ b/src/Makefile.test.include
@@ -63,6 +63,7 @@ BITCOIN_TESTS =\
   test/multisig_tests.cpp \
   test/net_tests.cpp \
   test/netbase_tests.cpp \
+  test/peer_tests.cpp \
   test/pmt_tests.cpp \
   test/policyestimator_tests.cpp \
   test/pow_tests.cpp \

--- a/src/main.h
+++ b/src/main.h
@@ -209,13 +209,10 @@ void UnregisterNodeSignals(CNodeSignals& nodeSignals);
  * specific block passed to it has been checked for validity!
  * 
  * @param[out]  state   This may be set to an Error state if any error occurred processing it, including during validation/connection/etc of otherwise unrelated blocks during reorganisation; or it may be set to an Invalid state if pblock is itself invalid (but this is not guaranteed even when the block is checked). If you want to *possibly* get feedback on whether pblock is valid, you must also install a CValidationInterface (see validationinterface.h) - this will have its BlockChecked method called whenever *any* block completes validation.
- * @param[in]   pfrom   The node which we are receiving the block from; it is added to mapBlockSource and may be penalised if the block is invalid.
  * @param[in]   pblock  The block we want to process.
- * @param[in]   fForceProcessing Process this block even if unrequested; used for non-network block sources and whitelisted peers.
- * @param[out]  dbp     The already known disk position of pblock, or NULL if not yet stored.
  * @return True if state.IsValid()
  */
-bool ProcessNewBlock(CValidationState& state, const CChainParams& chainparams, const CNode* pfrom, const CBlock* pblock, bool fForceProcessing, const CDiskBlockPos* dbp);
+bool ProcessNewBlock(CValidationState& state, const CChainParams& chainparams, const CBlock* pblock);
 /** Check whether enough disk space is available for an incoming block */
 bool CheckDiskSpace(uint64_t nAdditionalBytes = 0);
 /** Open a block file (blk?????.dat) */
@@ -286,8 +283,6 @@ void UnlinkPrunedFiles(std::set<int>& setFilesToPrune);
 CBlockIndex * InsertBlockIndex(uint256 hash);
 /** Get statistics from node state */
 bool GetNodeStateStats(NodeId nodeid, CNodeStateStats &stats);
-/** Increase a node's misbehavior score. */
-void Misbehaving(NodeId nodeid, int howmuch);
 /** Flush all state, indexes and buffers to disk. */
 void FlushStateToDisk();
 /** Prune block files and flush state to disk. */
@@ -305,6 +300,7 @@ ThresholdState VersionBitsTipState(const Consensus::Params& params, Consensus::D
 
 struct CNodeStateStats {
     int nMisbehavior;
+    bool fRelayTxes;
     int nSyncHeight;
     int nCommonHeight;
     std::vector<int> vHeightInFlight;

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -368,7 +368,7 @@ CNode* FindNode(const CService& addr)
     return NULL;
 }
 
-CNode* ConnectNode(CAddress addrConnect, const char *pszDest, bool fCountFailure)
+CNode* ConnectNode(CAddress addrConnect, const char *pszDest, bool fCountFailure, bool fOneShot)
 {
     if (pszDest == NULL) {
         if (IsLocal(addrConnect))
@@ -403,7 +403,7 @@ CNode* ConnectNode(CAddress addrConnect, const char *pszDest, bool fCountFailure
         addrman.Attempt(addrConnect, fCountFailure);
 
         // Add node
-        CNode* pnode = new CNode(hSocket, addrConnect, pszDest ? pszDest : "", false);
+        CNode* pnode = new CNode(hSocket, addrConnect, pszDest ? pszDest : "", false, fOneShot);
         pnode->AddRef();
 
         {
@@ -650,7 +650,6 @@ void CNode::copyStats(CNodeStats &stats)
 {
     stats.nodeid = this->GetId();
     X(nServices);
-    X(fRelayTxes);
     X(nLastSend);
     X(nLastRecv);
     X(nTimeConnected);
@@ -1010,9 +1009,8 @@ static void AcceptConnection(const ListenSocket& hListenSocket) {
         }
     }
 
-    CNode* pnode = new CNode(hSocket, addr, "", true);
+    CNode* pnode = new CNode(hSocket, addr, "", true, whitelisted);
     pnode->AddRef();
-    pnode->fWhitelisted = whitelisted;
 
     LogPrint("net", "connection from %s accepted\n", addr.ToString());
 
@@ -1697,7 +1695,7 @@ bool OpenNetworkConnection(const CAddress& addrConnect, bool fCountFailure, CSem
     } else if (FindNode(std::string(pszDest)))
         return false;
 
-    CNode* pnode = ConnectNode(addrConnect, pszDest, fCountFailure);
+    CNode* pnode = ConnectNode(addrConnect, pszDest, fCountFailure, fOneShot);
     boost::this_thread::interruption_point();
 
     if (!pnode)
@@ -1705,8 +1703,6 @@ bool OpenNetworkConnection(const CAddress& addrConnect, bool fCountFailure, CSem
     if (grantOutbound)
         grantOutbound->MoveTo(pnode->grantOutbound);
     pnode->fNetworkNode = true;
-    if (fOneShot)
-        pnode->fOneShot = true;
 
     return true;
 }
@@ -2326,12 +2322,14 @@ bool CAddrDB::Read(CAddrMan& addr, CDataStream& ssPeers)
 unsigned int ReceiveFloodSize() { return 1000*GetArg("-maxreceivebuffer", DEFAULT_MAXRECEIVEBUFFER); }
 unsigned int SendBufferSize() { return 1000*GetArg("-maxsendbuffer", DEFAULT_MAXSENDBUFFER); }
 
-CNode::CNode(SOCKET hSocketIn, const CAddress& addrIn, const std::string& addrNameIn, bool fInboundIn) :
+CNode::CNode(SOCKET hSocketIn, const CAddress& addrIn, const std::string& addrNameIn, bool fInboundIn, bool fWhitelistedIn, bool fOneShotIn) :
     ssSend(SER_NETWORK, INIT_PROTO_VERSION),
     addr(addrIn),
     nKeyedNetGroup(CalculateKeyedNetGroup(addrIn)),
     addrKnown(5000, 0.001),
-    filterInventoryKnown(50000, 0.000001)
+    filterInventoryKnown(50000, 0.000001),
+    fWhitelisted(fWhitelistedIn),
+    fOneShot(fOneShotIn)
 {
     nServices = NODE_NONE;
     nServicesExpected = NODE_NONE;
@@ -2346,9 +2344,6 @@ CNode::CNode(SOCKET hSocketIn, const CAddress& addrIn, const std::string& addrNa
     addrName = addrNameIn == "" ? addr.ToStringIPPort() : addrNameIn;
     nVersion = 0;
     strSubVer = "";
-    fWhitelisted = false;
-    fOneShot = false;
-    fClient = false; // set by version message
     fInbound = fInboundIn;
     fNetworkNode = false;
     fSuccessfullyConnected = false;
@@ -2364,7 +2359,6 @@ CNode::CNode(SOCKET hSocketIn, const CAddress& addrIn, const std::string& addrNa
     nNextLocalAddrSend = 0;
     nNextAddrSend = 0;
     nNextInvSend = 0;
-    fRelayTxes = false;
     fSentAddr = false;
     pfilter = new CBloomFilter();
     timeLastMempoolReq = 0;
@@ -2373,7 +2367,6 @@ CNode::CNode(SOCKET hSocketIn, const CAddress& addrIn, const std::string& addrNa
     nPingUsecTime = 0;
     fPingQueued = false;
     nMinPingUsecTime = std::numeric_limits<int64_t>::max();
-    minFeeFilter = 0;
     lastSentFeeFilter = 0;
     nextSendTimeFeeFilter = 0;
 
@@ -2405,7 +2398,8 @@ CNode::~CNode()
     if (pfilter)
         delete pfilter;
 
-    GetNodeSignals().FinalizeNode(GetId());
+    if (GetNodeSignals().FinalizeNode(GetId()))
+        AddressCurrentlyConnected(addr);
 }
 
 void CNode::AskFor(const CInv& inv)

--- a/src/net.h
+++ b/src/net.h
@@ -118,7 +118,7 @@ struct CNodeSignals
     boost::signals2::signal<bool (CNode*), CombinerAll> ProcessMessages;
     boost::signals2::signal<bool (CNode*), CombinerAll> SendMessages;
     boost::signals2::signal<void (NodeId, const CNode*)> InitializeNode;
-    boost::signals2::signal<void (NodeId)> FinalizeNode;
+    boost::signals2::signal<bool (NodeId)> FinalizeNode;
 };
 
 
@@ -189,7 +189,6 @@ class CNodeStats
 public:
     NodeId nodeid;
     ServiceFlags nServices;
-    bool fRelayTxes;
     int64_t nLastSend;
     int64_t nLastRecv;
     int64_t nTimeConnected;
@@ -347,18 +346,12 @@ public:
     // store the sanitized version in cleanSubVer. The original should be used when dealing with
     // the network or wire types and the cleaned string used when displayed or logged.
     std::string strSubVer, cleanSubVer;
-    bool fWhitelisted; // This peer can bypass DoS banning.
-    bool fOneShot;
-    bool fClient;
+    const bool fWhitelisted; // This peer can bypass DoS banning.
+    const bool fOneShot;
     bool fInbound;
     bool fNetworkNode;
     bool fSuccessfullyConnected;
     bool fDisconnect;
-    // We use fRelayTxes for two purposes -
-    // a) it allows us to not relay tx invs before receiving the peer's version message
-    // b) the peer may tell us in its version message that we should not relay tx invs
-    //    unless it loads a bloom filter.
-    bool fRelayTxes; //protected by cs_filter
     bool fSentAddr;
     CSemaphoreGrant grantOutbound;
     CCriticalSection cs_filter;
@@ -430,13 +423,10 @@ public:
     int64_t nMinPingUsecTime;
     // Whether a ping is requested.
     bool fPingQueued;
-    // Minimum fee rate with which to filter inv's to this node
-    CAmount minFeeFilter;
-    CCriticalSection cs_feeFilter;
     CAmount lastSentFeeFilter;
     int64_t nextSendTimeFeeFilter;
 
-    CNode(SOCKET hSocketIn, const CAddress &addrIn, const std::string &addrNameIn = "", bool fInboundIn = false);
+    CNode(SOCKET hSocketIn, const CAddress &addrIn, const std::string &addrNameIn = "", bool fInboundIn = false, bool fWhitelistedIn = false, bool fOneShotIn = false);
     ~CNode();
 
 private:

--- a/src/peer.cpp
+++ b/src/peer.cpp
@@ -1,0 +1,49 @@
+#include "peer.h"
+
+int Misbehavior::PeerInfo::Misbehaving(int delta) {
+    int badnessBefore = badness.fetch_add(delta, std::memory_order_relaxed);
+    int badnessAfter = badnessBefore + delta;
+    GetSignals().OnMisbehavior(static_cast<const Peer&>(*this), badnessBefore, badnessAfter);
+    if (IsExcessive(badnessAfter) && !IsExcessive(badnessBefore))
+        fExceeded.store(true, std::memory_order_release);
+    return badnessAfter;
+}
+
+void PeerManager::Register(NodeId id, std::shared_ptr<Peer>&& peer) {
+    lock_guard guard{csById};
+    auto ret = _byId.emplace(std::piecewise_construct,
+                            std::forward_as_tuple(id),
+                            std::forward_as_tuple(peer));
+    assert(ret.second);
+}
+
+void PeerManager::Unregister(NodeId id) {
+    lock_guard guard{csById};
+    auto it = _byId.find(id);
+    assert(it != _byId.end());
+    {
+        std::shared_ptr<Peer> ppeer = it->second;
+        const Peer::ConnectedInfo* pconnected = ppeer->GetConnectedInfo();
+        if (pconnected && pconnected->CanDownload() && ppeer->GetPreferredness() == DownloadPreferredness::ABOVE_NORMAL)
+            nPreferredDownload.fetch_sub(1, std::memory_order_relaxed);
+    }
+    _byId.erase(it);
+}
+
+std::shared_ptr<Peer> PeerManager::Get(NodeId id) {
+    lock_guard guard{csById};
+    auto it = _byId.find(id);
+    if (it == _byId.end())
+        return { nullptr };
+    else
+        return it->second;
+}
+
+bool PeerManager::IsPreferred(Peer& peer) const {
+    switch (peer.GetPreferredness()) {
+    case DownloadPreferredness::ABOVE_NORMAL: return true;
+    case DownloadPreferredness::BELOW_NORMAL: return false;
+    case DownloadPreferredness::NORMAL: return nPreferredDownload.load(std::memory_order_relaxed) == 0;
+    default: assert(!"unreachable!");
+    }
+}

--- a/src/peer.h
+++ b/src/peer.h
@@ -1,0 +1,292 @@
+#ifndef BITCOIN_PEER_H
+#define BITCOIN_PEER_H
+
+#include <boost/signals2/signal.hpp>
+
+#include <atomic>
+#include <list>
+#include <map>
+#include <mutex>
+#include <string>
+
+class CBlockIndex;
+typedef int NodeId;
+typedef int64_t CAmount;
+
+class Peer;
+
+namespace BlockAccountability {
+    namespace {
+        std::mutex csBlockRejects;
+    }
+    struct CBlockReject {
+        const CBlockIndex* pindex;
+        uint8_t chRejectCode;
+        std::string strRejectReason;
+        inline CBlockReject(const CBlockIndex* pindexIn, uint8_t chRejectCodeIn, std::string&& strRejectReasonIn)
+            : pindex(pindexIn), chRejectCode(chRejectCodeIn), strRejectReason(std::move(strRejectReasonIn)) {}
+    };
+    class PeerInfo {
+        typedef std::lock_guard<std::mutex> lock_guard;
+    public:
+        struct Params {};
+        inline PeerInfo(const Params& in) : fHaveRejects(false), _vRejects() {}
+        inline std::list<CBlockReject> GetBlockRejections() {
+            std::list<CBlockReject> ret;
+            if (fHaveRejects.load(std::memory_order_relaxed)) {
+                lock_guard guard{csBlockRejects};
+                ret.swap(_vRejects);
+                fHaveRejects.store(false, std::memory_order_relaxed);
+            }
+            return ret;
+        }
+        template <class... Args> void RejectBlock(Args&&... args) {
+            lock_guard guard{csBlockRejects};
+            _vRejects.emplace_back(std::forward<Args>(args)...);
+            fHaveRejects.store(true, std::memory_order_relaxed);
+        }
+    private:
+        // flag to skip the mutex for the common case
+        std::atomic<bool> fHaveRejects;
+        std::list<CBlockReject> _vRejects;
+    };
+} // namespace BlockAccountability
+
+namespace Misbehavior {
+    namespace {
+        int _banscore = 0;
+    }
+    // only set during initial setup
+    inline void _SetBanscore(int score) { _banscore = score; }
+    inline int GetBanscore() { return _banscore; }
+    inline bool IsExcessive(int score) { return score >= GetBanscore(); }
+
+    /// Hook for logging etc. when a peer misbehaves.
+    struct Signals {
+        boost::signals2::signal<void(const Peer&, int, int)> OnMisbehavior;
+    };
+    inline Signals& GetSignals() { static Signals s{}; return s; }
+
+    struct PeerInfo {
+        struct Params {
+            inline Params() : fNoBan(false), fNoDisconnect(false) {}
+            bool fNoBan;
+            bool fNoDisconnect;
+        };
+        inline PeerInfo(const Params& in)
+            : noDisconnect(in.fNoDisconnect)
+            , noBan(in.fNoBan)
+            , badness(0)
+            , fExceeded(false)
+        {}
+
+        inline int GetMisbehavior() const { return badness.load(std::memory_order_relaxed); }
+        int Misbehaving(int delta);
+
+        /// If a call to Misbehaving causes a peer's misbehavior to exceed GetBanscore(),
+        /// this function will return true exactly once. Otherwise returns false.
+        inline bool ExceededMisbehaviorThreshold() {
+            // Quick check for the usual case.
+            if (!fExceeded.load(std::memory_order_relaxed))
+                return false;
+            // Reread in case multiple concurrent callers.
+            // Release-acquire sync with Misbehaving() so if we return true,
+            // subsequent GetMisbehavior() will return at least GetBanscore().
+            return fExceeded.exchange(false, std::memory_order_acquire);
+        }
+
+        inline bool CanDisconnect() const { return !noDisconnect; }
+        inline bool CanBan() const { return !noBan; }
+    private:
+        const bool noDisconnect;
+        const bool noBan;
+        std::atomic<int> badness;
+        std::atomic<bool> fExceeded;
+    };
+} // namespace Misbehavior
+
+struct HeaderSync {
+    struct PeerInfo {
+        friend class HeaderSync;
+        struct Params {};
+        inline PeerInfo(const Params& in)
+            : fPreferHeaders(false)
+            , fSyncStarted(false)
+        {}
+
+        inline bool PrefersHeaders() const { return fPreferHeaders.load(std::memory_order_relaxed); }
+        inline void SetPrefersHeaders() { fPreferHeaders.store(true, std::memory_order_relaxed); }
+        inline bool IsSyncStarted() const { return fSyncStarted.load(std::memory_order_relaxed); }
+    private:
+        // sets fSyncStarted to true exactly once
+        // returns whether successfully changed
+        inline bool SetStarted() { return fSyncStarted.exchange(true, std::memory_order_relaxed); }
+
+        //! Whether the peer prefers headers to block invs
+        std::atomic<bool> fPreferHeaders;
+        //! Whether we've started headers synchronization with this peer.
+        std::atomic<bool> fSyncStarted;
+    };
+    inline HeaderSync() : fHaveSyncStarted(false) {}
+    /// Sets sync started, unless sync is already started.
+    /// Returns whether SyncStarted has been changed.
+    inline bool Start(PeerInfo& peer) {
+        // unconditional store - SetStarted only fails when the peer is already started
+        fHaveSyncStarted.store(true, std::memory_order_relaxed);
+        return peer.SetStarted();
+    }
+    /// Sets sync started, if no peers are already syncing.
+    /// Returns whether the peer has been set to started.
+    inline bool StartFirst(PeerInfo& peer) {
+        // quick check for the common case
+        if (fHaveSyncStarted.load(std::memory_order_relaxed) == true)
+            return false;
+        // if concurrent StartFirsts, only 1 may pass
+        if (fHaveSyncStarted.exchange(true, std::memory_order_relaxed) == true)
+            return false;
+        // will succeed unless concurrent unconditional Start for the same peer
+        return peer.SetStarted();
+    }
+private:
+    std::atomic<bool> fHaveSyncStarted;
+};
+
+namespace TxRelay {
+    struct PeerInfo {
+        struct Params {
+            inline Params() : fAlwaysRelayTx(false) {}
+            bool fAlwaysRelayTx;
+        };
+        inline PeerInfo(const Params& in) : fRelayTx(false), amtMinFeeFilter(0), fAlwaysRelayTx(in.fAlwaysRelayTx) {}
+
+        inline void SetRelayTx(bool value) { fRelayTx.store(value, std::memory_order_relaxed); }
+        inline bool CanRelayTx() { return fRelayTx.load(std::memory_order_relaxed); }
+
+        inline bool AlwaysRelayTx() { return fAlwaysRelayTx; }
+
+        inline void SetMinFeeFilter(CAmount value) { return amtMinFeeFilter.store(value, std::memory_order_relaxed); }
+        inline CAmount GetMinFeeFilter() const { return amtMinFeeFilter.load(std::memory_order_relaxed); }
+    private:
+        std::atomic<bool> fRelayTx;
+        std::atomic<CAmount> amtMinFeeFilter;
+        const bool fAlwaysRelayTx;
+    };
+} // namespace TxRelay
+
+enum class DownloadPreferredness { BELOW_NORMAL, NORMAL, ABOVE_NORMAL };
+
+/// Peer holds high-level information about a peer.
+class Peer
+    : public BlockAccountability::PeerInfo
+    , public Misbehavior::PeerInfo
+    , public HeaderSync::PeerInfo
+    , public TxRelay::PeerInfo
+{
+    friend class PeerManager;
+public:
+    struct Params
+        : public BlockAccountability::PeerInfo::Params
+        , public Misbehavior::PeerInfo::Params
+        , public HeaderSync::PeerInfo::Params
+        , public TxRelay::PeerInfo::Params
+    {
+        friend class Peer;
+        inline Params(NodeId idIn, const std::string& strNameIn)
+            : preferedness(DownloadPreferredness::NORMAL)
+            , id(idIn)
+            , strName(strNameIn)
+        {}
+        DownloadPreferredness preferedness;
+    private:
+        const NodeId id;
+        std::string strName;
+    };
+
+    // Applicable to a peer that has finished connecting (by sending its version
+    // message, though the handshake may not yet have been completed with a verack).
+    struct ConnectedInfo {
+        inline ConnectedInfo() : fEnableDownload(false), fPingSupported(false) {}
+
+        inline bool CanDownload() const { return fEnableDownload; }
+        inline bool IsPingSupported() const { return fPingSupported; }
+
+        inline void SetCanDownload(bool value) { fEnableDownload = value; }
+        inline void SetPingSupported(bool value) { fPingSupported = value; }
+    private:
+        // These properties can only be written before giving the ConnectedInfo
+        // to SetConnected; once they're accessible through GetConnectedInfo,
+        // only read access is allowed.
+        bool fEnableDownload;
+        bool fPingSupported;
+    };
+
+    inline Peer(Params&& in)
+        : BlockAccountability::PeerInfo(in)
+        , Misbehavior::PeerInfo(in)
+        , HeaderSync::PeerInfo(in)
+        , TxRelay::PeerInfo(in)
+        , id(in.id)
+        , strName(std::move(in.strName))
+        , preferedness(in.preferedness)
+        , pconnected(nullptr)
+    {}
+    inline ~Peer() { delete pconnected.load(std::memory_order_consume); }
+
+    inline NodeId GetId() const { return id; }
+    inline const std::string& GetName() const { return strName; }
+    inline bool operator!=(const Peer& other) const { return GetId() != other.GetId(); }
+    inline bool operator==(const Peer& other) const { return GetId() == other.GetId(); }
+
+    inline void SetHandshakeCompleted() { fHandshook.store(true, std::memory_order_relaxed); }
+    inline bool IsHandshakeCompleted() { return fHandshook.load(std::memory_order_relaxed); }
+
+    [[carries_dependency]] inline const ConnectedInfo* GetConnectedInfo() const {
+        // Release-consume because consumer must not observe pointer value that
+        // is more recent than the value written to it.
+        return pconnected.load(std::memory_order_consume);
+    }
+private:
+    inline void SetConnectedInfo(std::unique_ptr<ConnectedInfo>&& pnew) {
+        return pconnected.store(pnew.release(), std::memory_order_release);
+    }
+
+    inline DownloadPreferredness GetPreferredness() const { return preferedness; }
+
+    const NodeId id;
+    const std::string strName;
+    //! Whether we have a fully-established connection.
+    std::atomic<bool> fHandshook;
+    //! Whether we consider this a preferred download peer.
+    const DownloadPreferredness preferedness;
+    std::atomic<ConnectedInfo*> pconnected;
+};
+
+class PeerManager {
+    typedef std::lock_guard<std::mutex> lock_guard;
+public:
+    inline void SetConnected(Peer& peer, std::unique_ptr<Peer::ConnectedInfo>&& pconnected) {
+        if (pconnected->CanDownload()) {
+            if (peer.GetPreferredness() == DownloadPreferredness::ABOVE_NORMAL)
+                nPreferredDownload.fetch_add(1, std::memory_order_relaxed);
+        }
+        peer.SetConnectedInfo(std::move(pconnected));
+    }
+
+    void Register(NodeId id, std::shared_ptr<Peer>&& peer);
+    void Unregister(NodeId id);
+    std::shared_ptr<Peer> Get(NodeId id);
+
+    inline void Clear() {
+        lock_guard guard{csById};
+        _byId.clear();
+    }
+
+    bool IsPreferred(Peer& peer) const;
+private:
+    std::atomic<uint32_t> nPreferredDownload;
+
+    std::mutex csById;
+    std::map<NodeId, std::shared_ptr<Peer>> _byId;
+};
+
+#endif // BITCOIN_PEER_H

--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -131,7 +131,7 @@ UniValue generateBlocks(boost::shared_ptr<CReserveScript> coinbaseScript, int nG
             continue;
         }
         CValidationState state;
-        if (!ProcessNewBlock(state, Params(), NULL, pblock, true, NULL))
+        if (!ProcessNewBlock(state, Params(), pblock))
             throw JSONRPCError(RPC_INTERNAL_ERROR, "ProcessNewBlock, block not accepted");
         ++nHeight;
         blockHashes.push_back(pblock->GetHash().GetHex());
@@ -722,7 +722,7 @@ UniValue submitblock(const UniValue& params, bool fHelp)
     CValidationState state;
     submitblock_StateCatcher sc(block.GetHash());
     RegisterValidationInterface(&sc);
-    bool fAccepted = ProcessNewBlock(state, Params(), NULL, &block, true, NULL);
+    bool fAccepted = ProcessNewBlock(state, Params(), &block);
     UnregisterValidationInterface(&sc);
     if (fBlockPresent)
     {

--- a/src/rpc/net.cpp
+++ b/src/rpc/net.cpp
@@ -143,7 +143,7 @@ UniValue getpeerinfo(const UniValue& params, bool fHelp)
         if (!(stats.addrLocal.empty()))
             obj.push_back(Pair("addrlocal", stats.addrLocal));
         obj.push_back(Pair("services", strprintf("%016x", stats.nServices)));
-        obj.push_back(Pair("relaytxes", stats.fRelayTxes));
+        obj.push_back(Pair("relaytxes", statestats.fRelayTxes));
         obj.push_back(Pair("lastsend", stats.nLastSend));
         obj.push_back(Pair("lastrecv", stats.nLastRecv));
         obj.push_back(Pair("bytessent", stats.nSendBytes));

--- a/src/test/miner_tests.cpp
+++ b/src/test/miner_tests.cpp
@@ -114,7 +114,7 @@ BOOST_AUTO_TEST_CASE(CreateNewBlock_validity)
         pblock->hashMerkleRoot = BlockMerkleRoot(*pblock);
         pblock->nNonce = blockinfo[i].nonce;
         CValidationState state;
-        BOOST_CHECK(ProcessNewBlock(state, chainparams, NULL, pblock, true, NULL));
+        BOOST_CHECK(ProcessNewBlock(state, chainparams, pblock));
         BOOST_CHECK(state.IsValid());
         pblock->hashPrevBlock = pblock->GetHash();
     }

--- a/src/test/peer_tests.cpp
+++ b/src/test/peer_tests.cpp
@@ -1,0 +1,103 @@
+// Copyright (c) 2011-2015 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+// Unit tests for Peer code
+
+#include "peer.h"
+
+#include <boost/test/unit_test.hpp>
+
+BOOST_AUTO_TEST_SUITE(Peer_tests)
+
+PeerManager pm;
+
+BOOST_AUTO_TEST_CASE(Peer_peermgr)
+{
+    // make and register a typical peer
+    constexpr int NODE_ID = 15;
+    const std::string NODE_NAME = "node name";
+    Peer::Params params{NODE_ID, NODE_NAME};
+    params.fNoBan = false;
+    params.fNoDisconnect = false;
+    pm.Register(NODE_ID, std::make_shared<Peer>(std::move(params)));
+
+    // get it back
+    {
+        auto ppeer = pm.Get(NODE_ID);
+        BOOST_CHECK(ppeer->GetId() == NODE_ID);
+        BOOST_CHECK(ppeer->GetName() == NODE_NAME);
+        BOOST_CHECK(ppeer->CanDisconnect() == true);
+        BOOST_CHECK(ppeer->CanBan() == true);
+    }
+
+    pm.Unregister(NODE_ID);
+    assert(!pm.Get(NODE_ID));
+}
+
+static void SetConnectedDownloadable(Peer& peer)
+{
+    std::unique_ptr<Peer::ConnectedInfo> pconn{new Peer::ConnectedInfo};
+    pconn->SetCanDownload(true);
+    pm.SetConnected(peer, std::move(pconn));
+}
+
+BOOST_AUTO_TEST_CASE(Peer_prefer)
+{
+    // low priority peer
+    Peer::Params params1{1, ""};
+    params1.preferedness = DownloadPreferredness::BELOW_NORMAL;
+    pm.Register(1, std::make_shared<Peer>(std::move(params1)));
+    auto pLow = pm.Get(1);
+    SetConnectedDownloadable(*pLow);
+    BOOST_CHECK(!pm.IsPreferred(*pLow));
+
+    // normal priority
+    Peer::Params params2{2, ""};
+    pm.Register(2, std::make_shared<Peer>(std::move(params2)));
+    auto pNormal1 = pm.Get(2);
+    SetConnectedDownloadable(*pNormal1);
+    BOOST_CHECK(pm.IsPreferred(*pNormal1));
+    Peer::Params params3{3, ""};
+    pm.Register(3, std::make_shared<Peer>(std::move(params3)));
+    auto pNormal2 = pm.Get(3);
+    SetConnectedDownloadable(*pNormal2);
+    BOOST_CHECK(pm.IsPreferred(*pNormal2));
+
+    // high priority
+    Peer::Params params4{4, ""};
+    params4.preferedness = DownloadPreferredness::ABOVE_NORMAL;
+    pm.Register(4, std::make_shared<Peer>(std::move(params4)));
+    auto pHigh1 = pm.Get(4);
+    SetConnectedDownloadable(*pHigh1);
+    BOOST_CHECK(pm.IsPreferred(*pHigh1));
+    BOOST_CHECK(!pm.IsPreferred(*pNormal1));
+    BOOST_CHECK(!pm.IsPreferred(*pNormal2));
+    Peer::Params params5{5, ""};
+    params5.preferedness = DownloadPreferredness::ABOVE_NORMAL;
+    pm.Register(5, std::make_shared<Peer>(std::move(params5)));
+    auto pHigh2 = pm.Get(5);
+    SetConnectedDownloadable(*pHigh2);
+    BOOST_CHECK(pm.IsPreferred(*pHigh2));
+    BOOST_CHECK(!pm.IsPreferred(*pNormal1));
+    BOOST_CHECK(!pm.IsPreferred(*pNormal2));
+}
+
+BOOST_AUTO_TEST_CASE(Peer_misbehavior_threshold)
+{
+    BOOST_CHECK(Misbehavior::GetBanscore() == 100);
+    Peer::Params params{40, ""};
+    pm.Register(40, std::make_shared<Peer>(std::move(params)));
+    auto ppeer = pm.Get(40);
+    assert(ppeer);
+    BOOST_CHECK(ppeer->GetMisbehavior() == 0);
+    BOOST_CHECK(!ppeer->ExceededMisbehaviorThreshold());
+    BOOST_CHECK(!Misbehavior::IsExcessive(ppeer->Misbehaving(50)));
+    BOOST_CHECK(!ppeer->ExceededMisbehaviorThreshold());
+    BOOST_CHECK(Misbehavior::IsExcessive(ppeer->Misbehaving(50)));
+    BOOST_CHECK(ppeer->ExceededMisbehaviorThreshold());
+    BOOST_CHECK(!ppeer->ExceededMisbehaviorThreshold());
+    BOOST_CHECK(Misbehavior::IsExcessive(ppeer->GetMisbehavior()));
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/test_bitcoin.cpp
+++ b/src/test/test_bitcoin.cpp
@@ -112,7 +112,7 @@ TestChain100Setup::CreateAndProcessBlock(const std::vector<CMutableTransaction>&
     while (!CheckProofOfWork(block.GetHash(), block.nBits, chainparams.GetConsensus())) ++block.nNonce;
 
     CValidationState state;
-    ProcessNewBlock(state, chainparams, NULL, &block, true, NULL);
+    ProcessNewBlock(state, chainparams, &block);
 
     CBlock result = block;
     delete pblocktemplate;


### PR DESCRIPTION
I wrote this as a reimplementation for #7942 but forgot to actually push it. The merged version of that PR is, as @gmaxwell brought up, prone to lock inversion. It actually has an inversion of cs_main/cs_filter; the conflicting locks are all taken in the same thread, but it's not good practice.

This uses a new mutex for the two Misbehavior()-related fields of CNodeState, and as an additional lock for mapNodeState. No other locks except addrman's (which is fully encapsulated) are taken while cs_misbehavior is held.

Also, tacked on the fix for the redundant variable from #7942 pointed out by @sipa.
