### PR TITLE
tinyformat: force USE_VARIADIC_TEMPLATES

### DIFF
--- a/src/tinyformat.h
+++ b/src/tinyformat.h
@@ -113,7 +113,7 @@ namespace tfm = tinyformat;
 
 // Define for C++11 variadic templates which make the code shorter & more
 // general.  If you don't define this, C++11 support is autodetected below.
-// #define TINYFORMAT_USE_VARIADIC_TEMPLATES
+#define TINYFORMAT_USE_VARIADIC_TEMPLATES
 
 
 //------------------------------------------------------------------------------

--- a/src/util.h
+++ b/src/util.h
@@ -76,40 +76,33 @@ int LogPrintStr(const std::string &str);
 
 #define LogPrintf(...) LogPrint(NULL, __VA_ARGS__)
 
-/**
- * When we switch to C++11, this can be switched to variadic templates instead
- * of this macro-based construction (see tinyformat.h).
- */
-#define MAKE_ERROR_AND_LOG_FUNC(n)                                        \
-    /**   Print to debug.log if -debug=category switch is given OR category is NULL. */ \
-    template<TINYFORMAT_ARGTYPES(n)>                                          \
-    static inline int LogPrint(const char* category, const char* format, TINYFORMAT_VARARGS(n))  \
-    {                                                                         \
-        if(!LogAcceptCategory(category)) return 0;                            \
-        return LogPrintStr(tfm::format(format, TINYFORMAT_PASSARGS(n))); \
-    }                                                                         \
-    /**   Log error and return false */                                        \
-    template<TINYFORMAT_ARGTYPES(n)>                                          \
-    static inline bool error(const char* format, TINYFORMAT_VARARGS(n))                     \
-    {                                                                         \
-        LogPrintStr("ERROR: " + tfm::format(format, TINYFORMAT_PASSARGS(n)) + "\n"); \
-        return false;                                                         \
-    }
+template<typename T1, typename... Args>
+static inline int LogPrint(const char* category, const char* fmt, const T1& v1, const Args&... args)
+{
+    if(!LogAcceptCategory(category)) return 0;                            \
+    return LogPrintStr(tfm::format(fmt, v1, args...));
+}
 
-TINYFORMAT_FOREACH_ARGNUM(MAKE_ERROR_AND_LOG_FUNC)
+template<typename T1, typename... Args>
+bool error(const char* fmt, const T1& v1, const Args&... args)
+{
+    LogPrintStr("ERROR: " + tfm::format(fmt, v1, args...) + "\n");
+    return false;
+}
 
 /**
  * Zero-arg versions of logging and error, these are not covered by
- * TINYFORMAT_FOREACH_ARGNUM
+ * the variadic templates above (and don't take format arguments but
+ * bare strings).
  */
-static inline int LogPrint(const char* category, const char* format)
+static inline int LogPrint(const char* category, const char* s)
 {
     if(!LogAcceptCategory(category)) return 0;
-    return LogPrintStr(format);
+    return LogPrintStr(s);
 }
-static inline bool error(const char* format)
+static inline bool error(const char* s)
 {
-    LogPrintStr(std::string("ERROR: ") + format + "\n");
+    LogPrintStr(std::string("ERROR: ") + s + "\n");
     return false;
 }
 


### PR DESCRIPTION
Now that we started using c++11, force use of variadic templates.

The autodetection may be wonky on some compilers, see discussion [here](https://github.com/bitcoin/bitcoin/pull/7982#issuecomment-216222357) and is unnecessary for us anyhow.
