### PR TITLE
Add a comment indicating that the btc devs don't want a warning fixed

### DIFF
--- a/src/test/scheduler_tests.cpp
+++ b/src/test/scheduler_tests.cpp
@@ -28,6 +28,11 @@ static void microTask(CScheduler& s, boost::mutex& mutex, int& counter, int delt
     }
 }
 
+// NOTE: If you see a warning about this function being "defined but
+// not used [-Wunused-function]" the Bitcoin developers would rather
+// have you fix the test than this warning, and are using the warning
+// as a reminder that the test should be fixed. See pull request #7169
+// & #8003.
 static void MicroSleep(uint64_t n)
 {
 #if defined(HAVE_WORKING_BOOST_SLEEP_FOR)


### PR DESCRIPTION
The src/test/scheduler_tests.cpp test has been disabled since
v0.9.0rc2-4332-g8f0d79e, since then it's been warning about the
MicroSleep() function being unused, e.g. on GCC 4.9.2-10:

```
test/scheduler_tests.cpp:32:13: warning: ‘void
scheduler_tests::MicroSleep(uint64_t)’ defined but not used
[-Wunused-function]
```

The bitcoin developers don't want this warning fixed, and are instead
using it as a reminder to fix the test. Since this is a rather
unorthodox use of compiler warnings add a comment about this so people
who build bitcoin and notice compiler warnings don't try to submit
patches for this one.

See https://github.com/bitcoin/bitcoin/pull/8003 and
https://github.com/bitcoin/bitcoin/pull/7169 for past attempts to fix
this warning which have been rejected.
