### PR TITLE
Fix multithread CScheduler and reenable test

### DIFF
--- a/src/scheduler.cpp
+++ b/src/scheduler.cpp
@@ -79,6 +79,7 @@ void CScheduler::serviceQueue()
         }
     }
     --nThreadsServicingQueue;
+    newTaskScheduled.notify_one();
 }
 
 void CScheduler::stop(bool drain)

--- a/src/test/scheduler_tests.cpp
+++ b/src/test/scheduler_tests.cpp
@@ -40,7 +40,6 @@ static void MicroSleep(uint64_t n)
 #endif
 }
 
-#if 0 /* Disabled for now because there is a race condition issue in this test - see #6540 */
 BOOST_AUTO_TEST_CASE(manythreads)
 {
     seed_insecure_rand(false);
@@ -116,6 +115,5 @@ BOOST_AUTO_TEST_CASE(manythreads)
     }
     BOOST_CHECK_EQUAL(counterSum, 200);
 }
-#endif
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
This fixes the deadlock in the `CScheduler` when there are other `serviceQueue`s waiting for the new task to be added to the `taskQueue`, but `schedule` notifies only one of them who processes it and ends. And the other ones get stucked waiting for the new task which doesn't come in at all.

Hard to reproduce, see #6540 for the discussion.

Fixes #6540.
