### PR TITLE
python3 http module uses enum to define HTTP status codes

### DIFF
--- a/test/functional/interface_http.py
+++ b/test/functional/interface_http.py
@@ -7,7 +7,7 @@
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import *
 
-import http.client
+import http
 import urllib.parse
 
 class HTTPBasicsTest (BitcoinTestFramework):
@@ -95,13 +95,13 @@ class HTTPBasicsTest (BitcoinTestFramework):
         conn.connect()
         conn.request('GET', '/' + ('x'*1000), '', headers)
         out1 = conn.getresponse()
-        assert_equal(out1.status, http.client.NOT_FOUND)
+        assert_equal(out1.status, http.HTTPStatus.NOT_FOUND)
 
         conn = http.client.HTTPConnection(urlNode2.hostname, urlNode2.port)
         conn.connect()
         conn.request('GET', '/' + ('x'*10000), '', headers)
         out1 = conn.getresponse()
-        assert_equal(out1.status, http.client.BAD_REQUEST)
+        assert_equal(out1.status, http.HTTPStatus.BAD_REQUEST)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Fix for #12346.