### PR TITLE
[Qt] Show and store message of normal bitcoin:URI

### DIFF
--- a/src/qt/forms/sendcoinsentry.ui
+++ b/src/qt/forms/sendcoinsentry.ui
@@ -141,6 +141,23 @@
     <item row="2" column="1">
      <widget class="BitcoinAmountField" name="payAmount"/>
     </item>
+    <item row="3" column="0">
+     <widget class="QLabel" name="messageLabel">
+      <property name="text">
+       <string>Message:</string>
+      </property>
+      <property name="alignment">
+       <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+      </property>
+     </widget>
+    </item>
+    <item row="3" column="1">
+     <widget class="QLabel" name="messageTextLabel">
+      <property name="textFormat">
+       <enum>Qt::PlainText</enum>
+      </property>
+     </widget>
+    </item>
    </layout>
   </widget>
   <widget class="QFrame" name="SendCoins_InsecurePaymentRequest">

--- a/src/qt/sendcoinsentry.cpp
+++ b/src/qt/sendcoinsentry.cpp
@@ -88,6 +88,9 @@ void SendCoinsEntry::clear()
     ui->payTo->clear();
     ui->addAsLabel->clear();
     ui->payAmount->clear();
+    ui->messageTextLabel->clear();
+    ui->messageTextLabel->hide();
+    ui->messageLabel->hide();
     // clear UI elements for insecure payment request
     ui->payTo_is->clear();
     ui->memoTextLabel_is->clear();
@@ -148,6 +151,7 @@ SendCoinsRecipient SendCoinsEntry::getValue()
     recipient.address = ui->payTo->text();
     recipient.label = ui->addAsLabel->text();
     recipient.amount = ui->payAmount->value();
+    recipient.message = ui->messageTextLabel->text();
 
     return recipient;
 }
@@ -188,6 +192,11 @@ void SendCoinsEntry::setValue(const SendCoinsRecipient &value)
     }
     else // normal payment
     {
+        // message
+        ui->messageTextLabel->setText(recipient.message);
+        ui->messageTextLabel->setVisible(!recipient.message.isEmpty());
+        ui->messageLabel->setVisible(!recipient.message.isEmpty());
+
         ui->payTo->setText(recipient.address);
         ui->addAsLabel->setText(recipient.label);
         ui->payAmount->setValue(recipient.amount);

--- a/src/qt/transactiondesc.cpp
+++ b/src/qt/transactiondesc.cpp
@@ -224,6 +224,11 @@ QString TransactionDesc::toHTML(CWallet *wallet, CWalletTx &wtx, int vout, int u
 
         strHTML += "<b>" + tr("Transaction ID") + ":</b> " + TransactionRecord::formatSubTxId(wtx.GetHash(), vout) + "<br>";
 
+        // Message from normal bitcoin:URI (bitcoin:123...?message=example)
+        foreach (const PAIRTYPE(string, string)& r, wtx.vOrderForm)
+            if (r.first == "Message")
+                strHTML += "<br><b>" + tr("Message") + ":</b><br>" + GUIUtil::HtmlEscape(r.second, true) + "<br>";
+
         //
         // PaymentRequest info:
         //

--- a/src/qt/walletmodel.cpp
+++ b/src/qt/walletmodel.cpp
@@ -269,6 +269,8 @@ WalletModel::SendCoinsReturn WalletModel::sendCoins(WalletModelTransaction &tran
                 rcp.paymentRequest.SerializeToString(&value);
                 newTx->vOrderForm.push_back(make_pair(key, value));
             }
+            else if (!rcp.message.isEmpty()) // Message from normal bitcoin:URI (bitcoin:123...?message=example)
+                newTx->vOrderForm.push_back(make_pair("Message", rcp.message.toStdString()));
         }
 
         CReserveKey *keyChange = transaction.getPossibleKeyChange();


### PR DESCRIPTION
bitcoin:mrhz5ZgSF3C1BSdyCKt3gEdhKoRL5BNfJV?amount=0.0001&label=Donation&message=Thank%20you!

Message is shown in sendcoinsdialog and transaction details. Stored in walletTx->vOrderForm.

![message1](https://f.cloud.github.com/assets/2814559/1969649/3f5afb70-82f6-11e3-9db4-cb6b61d14fcd.png)

![message2](https://f.cloud.github.com/assets/2814559/1969651/4566dd72-82f6-11e3-82ee-65df1bbdf6da.png)
